### PR TITLE
Include dependencies in published pom file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'maven-publish'
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifact jar
+            from components.java
             artifact sourcesJar
 	    artifact javadocJar
         }


### PR DESCRIPTION
Currently, a modder has to specify `slick2d`, `netty` and `jopt` as dependencies in their `build.gradle` file.
With this change, these dependencies will be specified in the published `.pom` file. I have tested this change in a local repository.  
  
As a comparison I will include the pom file before and after this change.  
Before:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>de.ellpeck.rockbottom</groupId>
  <artifactId>RockBottomAPI</artifactId>
  <version>0.0.5-40</version>
</project>
```
After:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>de.ellpeck.rockbottom</groupId>
  <artifactId>RockBottomAPI</artifactId>
  <version>0.0.5-40</version>
  <dependencies>
    <dependency>
      <groupId>org.slick2d</groupId>
      <artifactId>slick2d-core</artifactId>
      <version>1.0.2</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-all</artifactId>
      <version>4.1.11.Final</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>net.sf.jopt-simple</groupId>
      <artifactId>jopt-simple</artifactId>
      <version>4.9</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```