### PR TITLE
Moved final localization to the Item itself

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/api/item/Item.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/item/Item.java
@@ -63,6 +63,10 @@ public class Item{
         return this.unlocName;
     }
 
+    public String getLocalizedName(ItemInstance instance){
+        return RockBottomAPI.getGame().getAssetManager().localize(this.getUnlocalizedName(instance));
+    }
+
     public void describeItem(IAssetManager manager, ItemInstance instance, List<String> desc, boolean isAdvanced){
         desc.add(instance.getDisplayName());
     }

--- a/src/main/java/de/ellpeck/rockbottom/api/item/ItemInstance.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/item/ItemInstance.java
@@ -197,7 +197,7 @@ public class ItemInstance{
     }
 
     public String getDisplayName(){
-        return RockBottomAPI.getGame().getAssetManager().localize(this.item.getUnlocalizedName(this));
+        return this.item.getLocalizedName(this);
     }
 
     @Override


### PR DESCRIPTION
A modder who is creating a item can now display to different locaization string within the same name. I would use it in my MOres mod to display 'Iron ingot' but 'Iron' and 'ingot' are two different localization entries, so I can dynamicly create the Item names instead of adding every manually to the localization file