### PR TITLE
Add a generic inventory interface

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/api/inventory/IHasInventory
+++ b/src/main/java/de/ellpeck/rockbottom/api/inventory/IHasInventory
@@ -1,0 +1,46 @@
+/*
+ * This file ("RockBottomAPI.java") is part of the RockBottomAPI by Ellpeck.
+ * View the source code at <https://github.com/Ellpeck/RockBottomAPI>.
+ *
+ * The RockBottomAPI is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The RockBottomAPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the RockBottomAPI. If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package de.ellpeck.rockbottom.api.inventory;
+
+import java.util.List;
+
+/*
+ * Generic inventory interface
+ * <br> Use this to store TileEntity inventory information
+ */
+public interface IHasInventory 
+{
+  /*
+   * The Inventory of the TileEntity. 
+   * <br> Can be any extension of Inventory
+   */
+	Inventory getInventory();
+  
+  /*
+   * The input slots from the Inventory container (RestrictedSlot instances)
+   * <br> Can be empty, or a list of the slot ID's from the container
+   */
+	List<Integer> getInputs();
+  
+  /*
+   * The valid output slots from the inventory container (OutputSlot instances)
+   * <br> Can be empty, or a list of the slot ID's from the container
+   */
+	List<Integer> getOutputs();
+}


### PR DESCRIPTION
Closes #6 

Adds an interface that allows for vanilla and modded inventories to work together. Currently mods need to re-write the inventory system from the base game in order to add machines and other inventory-carrying blocks, causing their inventory systems to be incompatible with vanilla. By implementing this class on every TileEntity that holds an inventory, all inventory systems that extend the vanilla Inventory class will work together and allows for easy implementation of item transportation in the future.

This only requires a tiny change to the base game code, adding three tiny methods each to TileEntitySmelter, TileEntitySeperator and TileEntityChest.