### PR TITLE
Update WorldGenOre.java

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/api/world/gen/WorldGenOre.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/world/gen/WorldGenOre.java
@@ -35,7 +35,7 @@ public abstract class WorldGenOre implements IWorldGenerator{
 
     @Override
     public void generate(IWorld world, IChunk chunk, Random rand){
-        int amount = rand.nextInt(this.getMaxAmount());
+        int amount = rand.nextInt(this.getMaxAmount() + 1);
         if(amount > 0){
             int radX = this.getClusterRadiusX();
             int radY = this.getClusterRadiusY();


### PR DESCRIPTION
rand.nextInt(amount) exclude the amount. You can't have amount to be 0, hence when you set getMaxAmount() to me 1 it will in fact return the 'amount' to be 0 and wont run.