### PR TITLE
Easily disable slot rendering & force a specific color

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/api/IRenderer.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/IRenderer.java
@@ -30,6 +30,7 @@ import de.ellpeck.rockbottom.api.item.ItemInstance;
 import de.ellpeck.rockbottom.api.render.engine.*;
 import de.ellpeck.rockbottom.api.util.ApiInternal;
 import de.ellpeck.rockbottom.api.util.Util;
+import de.ellpeck.rockbottom.api.data.settings.Settings;
 import org.lwjgl.opengl.GL15;
 
 import java.nio.FloatBuffer;
@@ -340,6 +341,13 @@ public interface IRenderer extends IDisposable {
      *                     be rendered in grayscale
      */
     void renderSlotInGui(IGameInstance game, IAssetManager manager, ItemInstance slot, float x, float y, float scale, boolean hovered, boolean canPlaceInto);
+
+    /**
+     * Renders a slot with additional arguments
+     * @param renderBackground Should the slot overlay be rendered? Usually true.
+     * @param colorOverride What color should the slot be? Usually {@link Settings#guiColor}
+     */
+    void renderSlotInGui(IGameInstance game, IAssetManager manager, ItemInstance slot, float x, float y, float scale, boolean hovered, boolean canPlaceInto, boolean renderBackground, int colorOverride);
 
     /**
      * Renders an item and its amount. This is similar to {@link

--- a/src/main/java/de/ellpeck/rockbottom/api/gui/component/ComponentSlot.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/gui/component/ComponentSlot.java
@@ -23,6 +23,7 @@ package de.ellpeck.rockbottom.api.gui.component;
 
 import de.ellpeck.rockbottom.api.IGameInstance;
 import de.ellpeck.rockbottom.api.IRenderer;
+import de.ellpeck.rockbottom.api.data.settings.Settings;
 import de.ellpeck.rockbottom.api.RockBottomAPI;
 import de.ellpeck.rockbottom.api.assets.IAssetManager;
 import de.ellpeck.rockbottom.api.gui.GuiContainer;
@@ -37,11 +38,34 @@ public class ComponentSlot extends GuiComponent {
     public final int componentId;
     public final GuiContainer container;
 
+    private boolean renderBackground = true;
+    private int colorOverride = -1;
+
     public ComponentSlot(GuiContainer container, ContainerSlot slot, int componentId, int x, int y) {
         super(container, x, y, 16, 16);
         this.container = container;
         this.slot = slot;
         this.componentId = componentId;
+    }
+
+    /**
+     * This disables the background rendering of the slot. Your slot will be
+     * invisible with this enabled if there are no items in it. You should
+     * probably only use this if your GUI texture includes its own slot markers.
+     */
+    public ComponentSlot setBackgroundRender(boolean backgroundRender) {
+        renderBackground = backgroundRender;
+        return this;
+    }
+
+    /**
+     * This forces your slot to render as a specific color. By default, slots
+     * will use the user-defined color preference {@link Settings#guiColor}
+     * @param color The color that you want your slot to use
+     */
+    public ComponentSlot setColorOverride(int color) {
+        this.colorOverride = color;
+        return this;
     }
 
     @Override
@@ -65,7 +89,7 @@ public class ComponentSlot extends GuiComponent {
     @Override
     public void render(IGameInstance game, IAssetManager manager, IRenderer g, int x, int y) {
         ItemInstance holding = this.container.getContainer().holdingInst;
-        g.renderSlotInGui(game, manager, this.slot.get(), x, y, 1F, this.isMouseOver(game), holding == null || this.slot.canPlace(holding));
+        g.renderSlotInGui(game, manager, this.slot.get(), x, y, 1F, this.isMouseOver(game), holding == null || this.slot.canPlace(holding), renderBackground, colorOverride);
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/api/gui/component/ComponentSlot.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/gui/component/ComponentSlot.java
@@ -39,6 +39,7 @@ public class ComponentSlot extends GuiComponent {
     public final GuiContainer container;
 
     private boolean renderBackground = true;
+    private boolean useColorOverride = false;
     private int colorOverride = -1;
 
     public ComponentSlot(GuiContainer container, ContainerSlot slot, int componentId, int x, int y) {
@@ -53,8 +54,8 @@ public class ComponentSlot extends GuiComponent {
      * invisible with this enabled if there are no items in it. You should
      * probably only use this if your GUI texture includes its own slot markers.
      */
-    public ComponentSlot setBackgroundRender(boolean backgroundRender) {
-        renderBackground = backgroundRender;
+    public ComponentSlot disableBackgroundRender() {
+        renderBackground = false;
         return this;
     }
 
@@ -63,7 +64,8 @@ public class ComponentSlot extends GuiComponent {
      * will use the user-defined color preference {@link Settings#guiColor}
      * @param color The color that you want your slot to use
      */
-    public ComponentSlot setColorOverride(int color) {
+    public ComponentSlot addColorOverride(int color) {
+        this.useColorOverride = true;
         this.colorOverride = color;
         return this;
     }
@@ -89,7 +91,7 @@ public class ComponentSlot extends GuiComponent {
     @Override
     public void render(IGameInstance game, IAssetManager manager, IRenderer g, int x, int y) {
         ItemInstance holding = this.container.getContainer().holdingInst;
-        g.renderSlotInGui(game, manager, this.slot.get(), x, y, 1F, this.isMouseOver(game), holding == null || this.slot.canPlace(holding), renderBackground, colorOverride);
+        g.renderSlotInGui(game, manager, this.slot.get(), x, y, 1F, this.isMouseOver(game), holding == null || this.slot.canPlace(holding), renderBackground, useColorOverride ? colorOverride : game.getSettings().guiColor);
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/api/gui/component/ComponentSlot.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/gui/component/ComponentSlot.java
@@ -91,7 +91,7 @@ public class ComponentSlot extends GuiComponent {
     @Override
     public void render(IGameInstance game, IAssetManager manager, IRenderer g, int x, int y) {
         ItemInstance holding = this.container.getContainer().holdingInst;
-        g.renderSlotInGui(game, manager, this.slot.get(), x, y, 1F, this.isMouseOver(game), holding == null || this.slot.canPlace(holding), renderBackground, useColorOverride ? colorOverride : game.getSettings().guiColor);
+        g.renderSlotInGui(game, manager, this.slot.get(), x, y, 1F, this.isMouseOver(game), holding == null || this.slot.canPlace(holding), renderBackground, useColorOverride ? colorOverride : getGuiColor());
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/api/gui/container/ContainerSlot.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/gui/container/ContainerSlot.java
@@ -34,6 +34,9 @@ public class ContainerSlot {
     public final int x;
     public final int y;
 
+    private boolean renderSlotBackground = true;
+    private int slotColorOverride = -1;
+
     public ContainerSlot(IInventory inventory, int slot, int x, int y) {
         this.inventory = inventory;
         this.slot = slot;
@@ -57,7 +60,17 @@ public class ContainerSlot {
         return this.inventory.get(this.slot);
     }
 
+    public ContainerSlot disableSlotBackgroundRender() {
+        renderSlotBackground = false;
+        return this;
+    }
+
+    public ContainerSlot setSlotColorOverride(int slotColorOverride) {
+        this.slotColorOverride = slotColorOverride;
+        return this;
+    }
+
     public ComponentSlot getGraphicalSlot(GuiContainer gui, int index, int xOffset, int yOffset) {
-        return new ComponentSlot(gui, this, index, xOffset + this.x, yOffset + this.y);
+        return new ComponentSlot(gui, this, index, xOffset + this.x, yOffset + this.y).setBackgroundRender(renderSlotBackground).setColorOverride(slotColorOverride);
     }
 }

--- a/src/main/java/de/ellpeck/rockbottom/api/gui/container/ContainerSlot.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/gui/container/ContainerSlot.java
@@ -35,7 +35,8 @@ public class ContainerSlot {
     public final int y;
 
     private boolean renderSlotBackground = true;
-    private int slotColorOverride = -1;
+    private boolean useSlotColorOverride = false;
+    private int slotColorOverride;
 
     public ContainerSlot(IInventory inventory, int slot, int x, int y) {
         this.inventory = inventory;
@@ -66,11 +67,15 @@ public class ContainerSlot {
     }
 
     public ContainerSlot setSlotColorOverride(int slotColorOverride) {
+        this.useSlotColorOverride = true;
         this.slotColorOverride = slotColorOverride;
         return this;
     }
 
     public ComponentSlot getGraphicalSlot(GuiContainer gui, int index, int xOffset, int yOffset) {
-        return new ComponentSlot(gui, this, index, xOffset + this.x, yOffset + this.y).setBackgroundRender(renderSlotBackground).setColorOverride(slotColorOverride);
+        ComponentSlot slot = new ComponentSlot(gui, this, index, xOffset + this.x, yOffset + this.y);
+        if (!renderSlotBackground) slot.disableBackgroundRender();
+        else if (useSlotColorOverride) slot.addColorOverride(slotColorOverride);
+        return slot;
     }
 }


### PR DESCRIPTION
This allows you to not render slot backgrounds and change their color without overriding multiple classes (ComponentSlot and ContainerSlot). Adding slots with no background or specific colors is now as easy as this:

```java
// This slot will have no background
this.addSlot(new RestrictedInputSlot(inv, 4, 109, 74).disableSlotBackgroundRender());
// This one will be black no matter what your GUI color is set to
this.addSlot(new RestrictedInputSlot(inv, 2, 109, 74).setSlotColorOverride(0xff000000));
```