### PR TITLE
Replace int based movement types with Enum for better readability. Al…

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/api/entity/player/AbstractPlayerEntity.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/entity/player/AbstractPlayerEntity.java
@@ -59,8 +59,14 @@ public abstract class AbstractPlayerEntity extends LivingEntity implements IComm
 
     public abstract void sendPacket(IPacket packet);
 
+    @Deprecated // use MoveType sensitive method instead
     @ApiInternal
-    public abstract boolean move(int type);
+    public boolean move(int type){
+        return type < MoveType.values().length && this.move(MoveType.values()[type]);
+    }
+
+    @ApiInternal
+    public abstract boolean move(MoveType type);
 
     @ApiInternal
     public abstract void onChunkLoaded(IChunk chunk);

--- a/src/main/java/de/ellpeck/rockbottom/api/entity/player/AbstractPlayerEntity.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/entity/player/AbstractPlayerEntity.java
@@ -59,12 +59,6 @@ public abstract class AbstractPlayerEntity extends LivingEntity implements IComm
 
     public abstract void sendPacket(IPacket packet);
 
-    @Deprecated // use MoveType sensitive method instead
-    @ApiInternal
-    public boolean move(int type){
-        return type < MoveType.values().length && this.move(MoveType.values()[type]);
-    }
-
     @ApiInternal
     public abstract boolean move(MoveType type);
 

--- a/src/main/java/de/ellpeck/rockbottom/api/entity/player/CameraMode.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/entity/player/CameraMode.java
@@ -66,17 +66,24 @@ public class CameraMode {
         RockBottomAPI.getGame().getRenderer().calcScales();
     }
 
-    public boolean move(int type) {
-        if (type == 0) { // Move Left
-            this.motionX = -this.getCameraSpeed();
-        } else if (type == 1) { // Move Right
-            this.motionX = this.getCameraSpeed();
-        } else if (type == 2) { // Jump
-            // No-Op
-        } else if (type == 3) { // Move Up
-            this.motionY = this.getCameraSpeed();
-        } else if (type == 4) { // Move Down
-            this.motionY = -this.getCameraSpeed();
+    public boolean move(MoveType type) {
+        switch (type) {
+            case LEFT: {
+                this.motionX = -this.getCameraSpeed();
+                break;
+            }
+            case RIGHT: {
+                this.motionX = this.getCameraSpeed();
+                break;
+            }
+            case UP: {
+                this.motionY = this.getCameraSpeed();
+                break;
+            }
+            case DOWN: {
+                this.motionY = -this.getCameraSpeed();
+                break;
+            }
         }
         return false;
     }

--- a/src/main/java/de/ellpeck/rockbottom/api/entity/player/MoveType.java
+++ b/src/main/java/de/ellpeck/rockbottom/api/entity/player/MoveType.java
@@ -1,0 +1,17 @@
+package de.ellpeck.rockbottom.api.entity.player;
+
+/**
+ * The MoveType Enum is used to determine how the player should move.
+ * It replaces the old integer based implementation, but the ordinals are equal to them.
+ *
+ * @see AbstractPlayerEntity#move(MoveType)
+ */
+public enum MoveType {
+
+    LEFT,
+    RIGHT,
+    JUMP,
+    UP,
+    DOWN
+
+}


### PR DESCRIPTION
…so changed if-else based statements to switch-case

Trello: https://trello.com/c/TqKn3Thq/19-add-movetype-enum-for-easier-readability-in-the-move-method-instead-of-int